### PR TITLE
chore: change engine to Node.js v14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,15 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        node-version: [14.x, 16.x, 18.x]      
     steps:
-    - uses: actions/checkout@v2
-    - name: Install Node.js 16
-      uses: actions/setup-node@v2
+    - uses: actions/checkout@v3
+    - name: Install Node.js v${{ matrix.node-version }}
+      uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: ${{ matrix.node-version }}
     - name: Install dependencies
       run: yarn install --immutable
     - name: CI

--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "0.3.2",
   "description": "TypeDoc plugin for resolving cross module reference in a mono-repository",
   "main": "dist",
-  "repository": "https://github.com/nlepage/typedoc-plugin-resolve-crossmodule-references",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nlepage/typedoc-plugin-resolve-crossmodule-references"
+  },
   "author": {
     "name": "Nicolas Lepage",
     "url": "https://github.com/nlepage"
@@ -13,7 +16,7 @@
     "typedoc-plugin"
   ],
   "engines": {
-    "node": ">=16"
+    "node": ">=14"
   },
   "files": [
     "dist"
@@ -27,7 +30,7 @@
   },
   "devDependencies": {
     "@ava/typescript": "^3.0.1",
-    "@tsconfig/node16": "^1.0.3",
+    "@tsconfig/node14": "^1.0.3",
     "@types/node": "^18.8.4",
     "ava": "^4.3.3",
     "prettier": "^2.7.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node16/tsconfig.json",
+  "extends": "@tsconfig/node14/tsconfig.json",
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "src"

--- a/yarn.lock
+++ b/yarn.lock
@@ -157,17 +157,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tsconfig/node14@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "@tsconfig/node14@npm:1.0.3"
+  checksum: 19275fe80c4c8d0ad0abed6a96dbf00642e88b220b090418609c4376e1cef81bf16237bf170ad1b341452feddb8115d8dd2e5acdfdea1b27422071163dc9ba9d
+  languageName: node
+  linkType: hard
+
 "@tsconfig/node16@npm:^1.0.2":
   version: 1.0.2
   resolution: "@tsconfig/node16@npm:1.0.2"
   checksum: ca94d3639714672bbfd55f03521d3f56bb6a25479bd425da81faf21f13e1e9d15f40f97377dedbbf477a5841c5b0c8f4cd1b391f33553d750b9202c54c2c07aa
-  languageName: node
-  linkType: hard
-
-"@tsconfig/node16@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "@tsconfig/node16@npm:1.0.3"
-  checksum: 3a8b657dd047495b7ad23437d6afd20297ce90380ff0bdee93fc7d39a900dbd8d9e26e53ff6b465e7967ce2adf0b218782590ce9013285121e6a5928fbd6819f
   languageName: node
   linkType: hard
 
@@ -2560,7 +2560,7 @@ __metadata:
   resolution: "typedoc-plugin-resolve-crossmodule-references@workspace:."
   dependencies:
     "@ava/typescript": ^3.0.1
-    "@tsconfig/node16": ^1.0.3
+    "@tsconfig/node14": ^1.0.3
     "@types/node": ^18.8.4
     ava: ^4.3.3
     prettier: ^2.7.1


### PR DESCRIPTION
The purpose of this change is to squelch a "bad engine" warning when installing under Node.js v14.

This package currently supports Node.js v14, but:

1. the `engines` field says otherwise, and
2. TS is configured to target Node.js v16

The resulting build artifact (`dist/index.js`) is _identical_ to the previous changeset.

To that end, I've changed the configuration and dependency from `@tsconfig/node16` to `@tsconfig/node14`.  I have also enabled the build to run across multiple Node.js versions and upgraded a couple actions while I was there.

It also looked like there was a problem [on npm](https://npm.im) referencing the repo, so I fiddled with the `repository` field.  Could just be old, though.

* * *
I totally understand why you might not want to merge this, however!

Thanks for this plugin.  We're using it in [appium](https://github.com/appium/appium).  